### PR TITLE
fix ftp deploy directory

### DIFF
--- a/.github/workflows/pullrequest-master.yml
+++ b/.github/workflows/pullrequest-master.yml
@@ -68,5 +68,5 @@ jobs:
           FTP_USERNAME: ${{ secrets.FTP_USERNAME }}
           FTP_PASSWORD: ${{ secrets.FTP_PASSWORD }}
           LOCAL_DIR: dist
-          REMOTE_DIR: ${{ secrets.FTP_DIR_DEV }}
+          REMOTE_DIR: www/event-dev/
           ARGS: --delete

--- a/.github/workflows/push-master.yml
+++ b/.github/workflows/push-master.yml
@@ -34,5 +34,5 @@ jobs:
           FTP_USERNAME: ${{ secrets.FTP_USERNAME }}
           FTP_PASSWORD: ${{ secrets.FTP_PASSWORD }}
           LOCAL_DIR: dist
-          REMOTE_DIR: ${{ secrets.FTP_DIR_PRDUCTION }}
+          REMOTE_DIR: www/event/
           ARGS: --delete


### PR DESCRIPTION
事故ったGithub Actionsのスクリプトを修正
サーバー側のデプロイ先ディレクトリの指定が間違ってたようです。